### PR TITLE
Bugfix: Timezones in DateTimePicker and SignupList

### DIFF
--- a/src/routes/Editor/components/DateTimePicker.js
+++ b/src/routes/Editor/components/DateTimePicker.js
@@ -24,7 +24,7 @@ class DateTimePicker extends React.PureComponent {
 
   toMoment(date) {
     return date
-      ? moment(date, 'YYYY-MM-DDTHH:mm').tz('Europe/Helsinki')
+      ? moment.tz(date, 'Europe/Helsinki')
       : moment()
           .tz('Europe/Helsinki')
           .hour(0)

--- a/src/routes/Editor/components/SignupList/SignupList.js
+++ b/src/routes/Editor/components/SignupList/SignupList.js
@@ -15,7 +15,7 @@ export class SignupList extends React.Component {
         <td>{index}.</td>
         <td>{firstName || 'Vahvistamatta'} {lastName || ''}</td>
         {this.props.questions.map((q, i) => <td key={i}>{getAnswer(answers, q.id) || ''}</td>)}
-        <td>{moment.tz(createdAt, 'Europe/Helsinki').format('DD.MM.YYYY hh:mm:ss')}<span className="hover">{moment.tz(createdAt, 'Europe/Helsinki').format('.SSS')}</span></td>
+        <td>{moment.tz(createdAt, 'Europe/Helsinki').format('DD.MM.YYYY HH:mm:ss')}<span className="hover">{moment.tz(createdAt, 'Europe/Helsinki').format('.SSS')}</span></td>
         <td><button
           onClick={() => window.alert(`Tsädääm nyt poistettais ${firstName} jos poistaminen toimis`)}
           className="btn btn-default btn-block">Poista</button> </td>

--- a/src/routes/SingleEvent/components/SignupList/SignupList.js
+++ b/src/routes/SingleEvent/components/SignupList/SignupList.js
@@ -15,7 +15,7 @@ export class SignupList extends React.Component {
         <td>{index}.</td>
         <td>{firstName || 'Vahvistamatta'} {lastName || ''}</td>
         {this.props.questions.map((q, i) => <td key={i}>{getAnswer(answers, q.id) || ''}</td>)}
-        <td>{moment.tz(createdAt, 'Europe/Helsinki').format('DD.MM.YYYY hh:mm:ss')}<span className="hover">{moment.tz(createdAt, 'Europe/Helsinki').format('.SSS')}</span></td>
+        <td>{moment.tz(createdAt, 'Europe/Helsinki').format('DD.MM.YYYY HH:mm:ss')}<span className="hover">{moment.tz(createdAt, 'Europe/Helsinki').format('.SSS')}</span></td>
       </tr>;
 
     return (

--- a/src/routes/SingleEvent/components/SignupList/SignupList.scss
+++ b/src/routes/SingleEvent/components/SignupList/SignupList.scss
@@ -12,12 +12,12 @@
 
 td {
   span.hover {
-    visiblity: visible;
+      visibility: hidden;
   }
 
   &:hover {
     span.hover {
-      visibility: hidden;
+    visibility: visible;
     }
   }
 }

--- a/src/utils/signupStateText.js
+++ b/src/utils/signupStateText.js
@@ -14,7 +14,7 @@ const signupState = (eventTime, starts, closes) => {
   const eventOpens = moment(eventTime);
   const now = moment();
 
-  const timeFormat = 'D.M.Y [klo] hh:mm';
+  const timeFormat = 'D.M.Y [klo] HH:mm';
 
   if (signupOpens.isSameOrAfter(now)) {
     return {


### PR DESCRIPTION
Fixes following bugs:
- When editing an event, the `<DateTimePicker/>` helper method `toMoment()` built applied the timezone to moment object after initializing it, which caused the original datetime to be modified by the timezone difference (eg. Event was created to start at 20:00, after saving and going back to modify it was 18:00)
- `<SignupList/>` used 12h formatting (`hh:mm`) instead of 24h (`HH:mm`) in some places
- Table of signees displayed signup time with millisecond precision and hid it when hovering (I assume the opposite is intended behaviour)