### PR TITLE
Add configurable URL prefix

### DIFF
--- a/bin/prod-server.js
+++ b/bin/prod-server.js
@@ -9,4 +9,4 @@ app.use(enforce.HTTPS({ trustProtoHeader: true }));
 
 const server = app.listen(process.env.PORT);
 
-server.on('listening', () => debug(`Server is now running at ${process.env.BASE_URL}.`));
+server.on('listening', () => debug(`Server is now running at ${process.env.BASE_URL}${process.env.PREFIX_URL}.`));

--- a/config/environments.config.js
+++ b/config/environments.config.js
@@ -16,7 +16,7 @@ module.exports = {
   // Overrides when NODE_ENV === 'production'
   // ======================================================
   production: () => ({
-    compiler_public_path: '/',
+    compiler_public_path: process.env.BASE_URL,
     compiler_fail_on_warning: false,
     compiler_hash_type: 'chunkhash',
     compiler_devtool: null,

--- a/config/environments.config.js
+++ b/config/environments.config.js
@@ -16,7 +16,7 @@ module.exports = {
   // Overrides when NODE_ENV === 'production'
   // ======================================================
   production: () => ({
-    compiler_public_path: process.env.BASE_URL,
+    compiler_public_path: process.env.PREFIX_URL,
     compiler_fail_on_warning: false,
     compiler_hash_type: 'chunkhash',
     compiler_devtool: null,

--- a/config/ilmomasiina.config.js
+++ b/config/ilmomasiina.config.js
@@ -9,9 +9,10 @@ const config = {
   feathersAuthSecret: process.env.FEATHERS_AUTH_SECRET,
   sendgridApiKey: process.env.SENDGRID_API_KEY,
   baseUrl: process.env.BASE_URL,
+  prefixUrl: process.env.PREFIX_URL,
   adminRegistrationAllowed: process.env.ADMIN_REGISTRATION_ALLOWED == "true" || false,
   brandingMailFooterText: process.env.BRANDING_MAIL_FOOTER_TEXT,
-  brandingMailFooterLink: process.env.BASE_URL,
+  brandingMailFooterLink: `${process.env.BASE_URL}${process.env.PREFIX_URL || ''}`,
 };
 
 _.forOwn(config, (value, key) => {

--- a/config/ilmomasiina.config.js
+++ b/config/ilmomasiina.config.js
@@ -9,7 +9,7 @@ const config = {
   feathersAuthSecret: process.env.FEATHERS_AUTH_SECRET,
   sendgridApiKey: process.env.SENDGRID_API_KEY,
   baseUrl: process.env.BASE_URL,
-  prefixUrl: process.env.PREFIX_URL,
+  prefixUrl: process.env.PREFIX_URL || '',
   adminRegistrationAllowed: process.env.ADMIN_REGISTRATION_ALLOWED == "true" || false,
   brandingMailFooterText: process.env.BRANDING_MAIL_FOOTER_TEXT,
   brandingMailFooterLink: `${process.env.BASE_URL}${process.env.PREFIX_URL || ''}`,

--- a/config/project.config.js
+++ b/config/project.config.js
@@ -84,6 +84,7 @@ config.globals = {
   TEST     : config.env === 'test',
   COVERAGE : !argv.watch && config.env === 'test',
   BASENAME : JSON.stringify(process.env.BASENAME || ''),
+  PREFIX_URL : JSON.stringify(process.env.PREFIX_URL || ''),
   BRANDING_HEADER_TITLE: JSON.stringify(process.env.BRANDING_HEADER_TITLE_TEXT),
   BRANDING_FOOTER_GDPR_TEXT: JSON.stringify(process.env.BRANDING_FOOTER_GDPR_TEXT),
   BRANDING_FOOTER_GDPR_LINK: JSON.stringify(process.env.BRANDING_FOOTER_GDPR_LINK),

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "compile": {
       "command": "node bin/compile",
       "env": {
+        "NODE_ENV": "production",
         "DEBUG": "app:*"
       }
     },
@@ -94,6 +95,7 @@
     "start:prod": {
       "command": "node bin/prod-server",
       "env": {
+        "NODE_ENV": "production",
         "DEBUG": "app:*"
       }
     },

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -14,21 +14,16 @@ module.exports = function () {
   const app = this;
 
   let sequelize;
-  if (process.env.NODE_ENV === 'production') {
-    sequelize = sequelizeHeroku.connect(Sequelize);
+  if (process.env.CLEARDB_DATABASE_URL) {
+    sequelize = new Sequelize(process.env.CLEARDB_DATABASE_URL, {
+      logging: false,
+    });
   } else {
-
-    if (process.env.CLEARDB_DATABASE_URL) {
-      sequelize = new Sequelize(process.env.CLEARDB_DATABASE_URL, {
-        logging: false,
-      });
-    } else {
-      sequelize = new Sequelize(config.mysqlDatabase, config.mysqlUser, config.mysqlPassword, {
-        host: 'localhost',
-        dialect: 'mysql',
-        logging: false,
-      });
-    }
+    sequelize = new Sequelize(config.mysqlDatabase, config.mysqlUser, config.mysqlPassword, {
+      host: 'localhost',
+      dialect: 'mysql',
+      logging: false,
+    });
   }
 
   if (sequelize) {

--- a/server/services/signup/hooks/sendConfirmationMail.js
+++ b/server/services/signup/hooks/sendConfirmationMail.js
@@ -43,7 +43,7 @@ module.exports = () => (hook) => {
             answers: fields,
             date: moment(event.dataValues.date).tz('Europe/Helsinki').format('DD.MM.YYYY HH:mm:ss'),
             event: event.dataValues,
-            cancelLink: `${config.baseUrl}/signup/${hook.result.id}/${hook.data.editToken}`,
+            cancelLink: `${config.baseUrl}${config.prefixUrl}/signup/${hook.result.id}/${hook.data.editToken}`,
           };
           // console.log(hook.data);
           // console.log('=====CONFIRMATION MAIL DISABLED!=====');

--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -5,7 +5,7 @@ import './Footer.scss';
 export const Footer = () => (
   <footer className="page-footer">
     <div className='container'>
-      <a onClick={() => browserHistory.push('/admin')}> Hallinta</a>
+      <a onClick={() => browserHistory.push(`${PREFIX_URL}/admin`)}> Hallinta</a>
       <a href={BRANDING_FOOTER_GDPR_LINK} className='navbar-link'>{BRANDING_FOOTER_GDPR_TEXT}</a>
       <a href={BRANDING_FOOTER_HOME_LINK} className='navbar-link'>{BRANDING_FOOTER_HOME_TEXT}</a>
     </div>

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -15,7 +15,7 @@ class Header extends React.Component {
     return (
       <div className="navbar navbar-default">
         <div className="container">
-          <a onClick={() => browserHistory.push('/')} className="navbar-brand">
+          <a onClick={() => browserHistory.push(`${PREFIX_URL}/`)} className="navbar-brand">
             {' '}
             {BRANDING_HEADER_TITLE}
           </a>

--- a/src/containers/AppContainer.js
+++ b/src/containers/AppContainer.js
@@ -40,12 +40,12 @@ class AppContainer extends Component {
           <div style={{ height: '100%' }}>
             <CoreLayout>
               <Router history={history}>
-                <Route path="/" component={Events} />
-                <Route path="event/:id" component={SingleEvent} />
-                <Route path="signup/:id/:editToken" component={EditSignup} />
-                <Route path="login" component={Login} />
-                <Route path="admin" component={requireAuth(Admin)} />
-                <Route path="admin/edit/:id" component={requireAuth(Editor)} />
+                <Route path={`${PREFIX_URL}/`} component={Events} />
+                <Route path={`${PREFIX_URL}/event/:id`} component={SingleEvent} />
+                <Route path={`${PREFIX_URL}/signup/:id/:editToken`} component={EditSignup} />
+                <Route path={`${PREFIX_URL}/login`} component={Login} />
+                <Route path={`${PREFIX_URL}/admin`} component={requireAuth(Admin)} />
+                <Route path={`${PREFIX_URL}/admin/edit/:id`} component={requireAuth(Editor)} />
                 <Route path="*" component={PageNotFound} />
                 <Route />
               </Router>

--- a/src/modules/admin/actions.js
+++ b/src/modules/admin/actions.js
@@ -26,7 +26,7 @@ export const getEventsAsync = () => (dispatch, getState) => {
 
   const accessToken = getState().admin.accessToken;
 
-  request('GET', '/api/admin/events', {
+  request('GET', `${PREFIX_URL}/api/admin/events`, {
     headers: { Authorization: accessToken },
   })
     .then(res => JSON.parse(res.body))
@@ -42,7 +42,7 @@ export const getEventsAsync = () => (dispatch, getState) => {
 export const createUserAsync = (data) => (dispatch, getState) => {
   const accessToken = getState().admin.accessToken;
   console.log(email)
-  return request('POST', '/api/users', {
+  return request('POST', `${PREFIX_URL}/api/users`, {
     headers: { Authorization: accessToken },
     json: { email: data.email }
   })
@@ -86,7 +86,7 @@ export const setLoginError = () => dispatch => {
 export const login = (email, password) => dispatch => {
   dispatch(setLoginLoading());
 
-  request('POST', '/api/authentication', {
+  request('POST', `${PREFIX_URL}/api/authentication`, {
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: `strategy=local&email=${email}&password=${password}`,
   })
@@ -103,7 +103,7 @@ export const login = (email, password) => dispatch => {
       }
       dispatch(setAccessToken(res.accessToken));
       dispatch({ type: ActionTypes.SET_LOGIN_STATUS, payload: true });
-      dispatch(push('/admin'));
+      dispatch(push(`${PREFIX_URL}/admin`));
     })
     .catch(error => {
       console.error('Error in login', error);
@@ -113,13 +113,13 @@ export const login = (email, password) => dispatch => {
 
 export const redirectToLogin = () => dispatch => {
   dispatch(clearState());
-  dispatch(push('/login'));
+  dispatch(push(`${PREFIX_URL}/login`));
 };
 
 export const deleteEventAsync = id => (dispatch, getState) => {
   const accessToken = getState().admin.accessToken;
 
-  return request('DELETE', `/api/admin/events/${id}`, {
+  return request('DELETE', `${PREFIX_URL}/api/admin/events/${id}`, {
     headers: { Authorization: accessToken },
   })
     .then(res => {

--- a/src/modules/editSignup/actions.js
+++ b/src/modules/editSignup/actions.js
@@ -38,7 +38,7 @@ export const resetEventState = () => (dispatch) => {
 export const getSignupAndEventAsync = (id, editToken) => (dispatch) => {
   dispatch(setLoading());
 
-  return request('GET', `/api/signups/${id}?editToken=${editToken}`)
+  return request('GET', `${PREFIX_URL}/api/signups/${id}?editToken=${editToken}`)
     .then(res => JSON.parse(res.body))
     .then((res) => {
       dispatch(setSignupAndEvent(res.signup, res.event));
@@ -53,7 +53,7 @@ export const getSignupAndEventAsync = (id, editToken) => (dispatch) => {
 
 export const deleteSignupAsync = (id, editToken) => (dispatch) => {
   dispatch(setLoading());
-  return request('DELETE', `/api/signups/${id}?editToken=${editToken}`)
+  return request('DELETE', `${PREFIX_URL}/api/signups/${id}?editToken=${editToken}`)
     .then(res => JSON.parse(res.body))
     .then((res) => {
       dispatch(setDeleted());

--- a/src/modules/editor/actions.js
+++ b/src/modules/editor/actions.js
@@ -88,7 +88,7 @@ export const publishEventAsync = (data, token) => async (dispatch) => {
   dispatch(setEventPublishLoading());
   const cleaned = cleanEventData(data);
   console.log('CLEANED', cleaned);
-  const event = await request('POST', '/api/admin/events', {
+  const event = await request('POST', `${PREFIX_URL}/api/admin/events`, {
     json: cleaned,
     headers: { Authorization: token },
   }).then(res => {
@@ -116,7 +116,7 @@ export const updateEventAsync = (data, token) => async (dispatch) => {
   dispatch(setEventPublishLoading());
   const cleaned = cleanEventData(data);
   console.log('CLEANED', cleaned);
-  const event = await request('PATCH', `/api/admin/events/${data.id}`, {
+  const event = await request('PATCH', `${PREFIX_URL}/api/admin/events/${data.id}`, {
     json: cleaned,
     headers: { Authorization: token },
   }).then(res => {
@@ -142,7 +142,7 @@ export const updateEventAsync = (data, token) => async (dispatch) => {
 
 export const getEventAsync = (eventId, token) => async (dispatch) => {
   dispatch(setEventLoading());
-  const res = await request('GET', `/api/admin/events/${eventId}`, {
+  const res = await request('GET', `${PREFIX_URL}/api/admin/events/${eventId}`, {
     headers: { Authorization: token },
   }).then(res => JSON.parse(res.body))
     .then((res) => {

--- a/src/modules/events/actions.js
+++ b/src/modules/events/actions.js
@@ -22,7 +22,7 @@ export const setEventsError = () => (dispatch) => {
 
 export const getEventsAsync = () => (dispatch) => {
   dispatch(setEventsLoading());
-  request('GET', '/api/events')
+  request('GET', `${PREFIX_URL}/api/events`)
     .then(res => JSON.parse(res.body))
     .then((res) => {
       dispatch(setEvents(res));

--- a/src/modules/singleEvent/actions.js
+++ b/src/modules/singleEvent/actions.js
@@ -27,7 +27,7 @@ export const setSignupError = () => (dispatch) => {
 
 export const updateEventAsync = eventId => (dispatch) => {
   dispatch(setEventLoading());
-  return request('GET', `/api/events/${eventId}`)
+  return request('GET', `${PREFIX_URL}/api/events/${eventId}`)
     .then(res => JSON.parse(res.body))
     .then((res) => {
       dispatch(setEvent(res));
@@ -40,7 +40,7 @@ export const updateEventAsync = eventId => (dispatch) => {
 
 export const attachPositionAsync = quotaId => (dispatch) => {
   dispatch(setSignupLoading());
-  return request('POST', '/api/signups', { json: { quotaId } })
+  return request('POST', `${PREFIX_URL}/api/signups`, { json: { quotaId } })
     .then(res => JSON.parse(res.body))
     .then((res) => {
       dispatch(setSignup(res));
@@ -54,7 +54,7 @@ export const attachPositionAsync = quotaId => (dispatch) => {
 export const completeSignupAsync = (signupId, data) => (dispatch) => {
   dispatch(setSignupLoading());
 
-  return request('PATCH', `/api/signups/${signupId}`, {
+  return request('PATCH', `${PREFIX_URL}/api/signups/${signupId}`, {
     json: {
       editToken: data.editToken,
       firstName: data.firstName,
@@ -83,7 +83,7 @@ export const completeSignupAsync = (signupId, data) => (dispatch) => {
 
 export const cancelSignupAsync = (signupId, editToken) => (dispatch) => {
   dispatch(setSignupLoading());
-  return request('DELETE', `/api/signups/${signupId}?editToken=${editToken}`)
+  return request('DELETE', `${PREFIX_URL}/api/signups/${signupId}?editToken=${editToken}`)
     .then(res => JSON.parse(res.body))
     .then(() => {
       dispatch(setSignup({}));

--- a/src/routes/404/PageNotFound.js
+++ b/src/routes/404/PageNotFound.js
@@ -6,7 +6,7 @@ const PageNotFound = () => (
     <h1>Virhe 404</h1>
     <p>Sivua ei löydy. Tapahtuma on varmaan vanhentunut ja poistettu näkyvistä.</p>
     <p>
-      <IndexLink to="/">Palaa etusivulle</IndexLink>
+      <IndexLink to={`${PREFIX_URL}/`}>Palaa etusivulle</IndexLink>
     </p>
   </div>
 );

--- a/src/routes/Admin/AdminEventListItem.js
+++ b/src/routes/Admin/AdminEventListItem.js
@@ -23,13 +23,13 @@ class AdminEventListItem extends React.Component {
     return (
       <tr>
         <td>
-          <Link to={`/event/${data.id}`}>{data.title}</Link>
+          <Link to={`${PREFIX_URL}/event/${data.id}`}>{data.title}</Link>
         </td>
         <td>{data.date ? moment(data.date).format('DD.MM.YYYY') : ''}</td>
         <td>{data.draft ? "Luonnos" : "Julkaistu"}</td>
         <td>{signups}</td>
         <td>
-          <Link to={`/admin/edit/${data.id}`}>Muokkaa tapahtumaa</Link>
+          <Link to={`${PREFIX_URL}/admin/edit/${data.id}`}>Muokkaa tapahtumaa</Link>
           {/* {<Separator />
             <CSVLink
               data={signups}

--- a/src/routes/Admin/AdminEventsList.js
+++ b/src/routes/Admin/AdminEventsList.js
@@ -109,7 +109,7 @@ class AdminEventList extends React.Component {
             {this.renderEventRows()}
           </tbody>
         </table>
-        <Link to="/admin/edit/new" className="btn btn-default">
+        <Link to={`${PREFIX_URL}/admin/edit/new`} className="btn btn-default">
           + Uusi tapahtuma
         </Link>
         <h1>Luo uusi käyttäjä</h1>

--- a/src/routes/Admin/index.js
+++ b/src/routes/Admin/index.js
@@ -2,7 +2,7 @@ import { injectReducer } from '../../store/reducers';
 import adminWrapper from '../authWrapper';
 
 export default store => ({
-  path: 'admin',
+  path: `${PREFIX_URL}/admin`,
   /*  Async getComponent is only invoked when route matches   */
   getComponent(nextState, cb) {
     /*  Webpack - use 'require.ensure' to create a split point

--- a/src/routes/EditSignup/EditSignup.js
+++ b/src/routes/EditSignup/EditSignup.js
@@ -41,7 +41,7 @@ class EditSignup extends React.Component {
           <div className="EditSignup--wrapper">
             <h1>Hups, jotain meni pieleen</h1>
             <p>Ilmoittautumistasi ei voi enää perua, koska tapahtuman ilmoittautuminen on sulkeutunut.</p>
-            <Link to="/" className="btn btn-default">
+            <Link to={`${PREFIX_URL}/`} className="btn btn-default">
               Takaisin etusivulle
             </Link>
           </div>
@@ -53,7 +53,7 @@ class EditSignup extends React.Component {
         <div className="container align-items-center">
           <div className="EditSignup--wrapper">
             <h1>Ilmoittautumisesi poistettiin onnistuneesti</h1>
-            <Link to="/" className="btn btn-default">
+            <Link to={`${PREFIX_URL}/`} className="btn btn-default">
               Takaisin etusivulle
             </Link>
           </div>

--- a/src/routes/Editor/Editor.js
+++ b/src/routes/Editor/Editor.js
@@ -107,7 +107,7 @@ class Editor extends React.Component {
       try {
         const res = await minDelay(this.props.publishEventAsync(event, adminToken), 1000);
         console.log('RES EDITOR', res);
-        browserHistory.push(`/admin/edit/${res.id}`);
+        browserHistory.push(`${PREFIX_URL}/admin/edit/${res.id}`);
       } catch (error) {
         console.log(error);
         toast.error('Jotain meni pieleen - tapahtuman luonti epäonnistui.', { autoClose: 2000 });
@@ -230,7 +230,7 @@ class Editor extends React.Component {
           <div className="event-editor--loading-container">
             <h1>Hups, jotain meni pieleen</h1>
             <p>{`Tapahtumaa id:llä "${this.props.params.id}" ei löytynyt`}</p>
-            <Link to="/admin/">Palaa tapahtumalistaukseen</Link>
+            <Link to={`${PREFIX_URL}/admin/`}>Palaa tapahtumalistaukseen</Link>
           </div>
         </div>
       );
@@ -240,7 +240,7 @@ class Editor extends React.Component {
 
     return (
       <div className="event-editor">
-        <Link to="/admin">&#8592; Takaisin</Link>
+        <Link to={`${PREFIX_URL}/admin`}>&#8592; Takaisin</Link>
         <Formsy.Form
           onValid={() => this.setValidState(true)}
           onInvalid={() => this.setValidState(false)}

--- a/src/routes/Events/EventList.js
+++ b/src/routes/Events/EventList.js
@@ -107,7 +107,7 @@ class EventList extends React.Component {
       const rows = [
         <TableRow
           title={event.title}
-          link={`/event/${event.id}`}
+          link={`${PREFIX_URL}/event/${event.id}`}
           date={event.date}
           signupLabel={eventState.label}
           signups={

--- a/src/routes/SingleEvent/SingleEvent.js
+++ b/src/routes/SingleEvent/SingleEvent.js
@@ -231,7 +231,7 @@ class SingleEvent extends React.Component {
           />
         ) : (
             <div className="container">
-              <Link to="/" style={{ margin: 0 }}>&#8592; Takaisin</Link>
+              <Link to={`${PREFIX_URL}/`} style={{ margin: 0 }}>&#8592; Takaisin</Link>
               <div className="row">
                 <div className="col-xs-12 col-sm-8">
                   <h1>{event.title}</h1>


### PR DESCRIPTION
This PR allows the user to better configure how they host the app. Previously all site routes and API calls relied on the service being hosted at web root (for example `http://localhost/` or `https://ilmo.athene.fi/`), but now after configuring an env variable `PREFIX_URL` the app can be hosted as a subpage (for example `https://www.inkubio.fi/ilmo/`). This has been tested to work for our Apache reverse proxy hosting solution @ Otax, but I have yet to test another hosting solution more similar to your current use case, so I hope you could give it a try and hit me up if something needs fixing :)