### PR TITLE
Feature/Serverside check of signup opening time

### DIFF
--- a/server/services/event/hooks/addOpenStatus.js
+++ b/server/services/event/hooks/addOpenStatus.js
@@ -1,0 +1,10 @@
+module.exports = () => (hook) => {
+  const startDate = new Date(hook.result.registrationStartDate);
+  const now = new Date();
+  const endDate = new Date(hook.result.registrationEndDate);
+  if (now > startDate && now < endDate) {
+    hook.result.dataValues.isOpen = true;
+  } else {
+    hook.result.dataValues.isOpen = false;
+  }
+};

--- a/server/services/event/hooks/index.js
+++ b/server/services/event/hooks/index.js
@@ -4,6 +4,7 @@ const includeQuotas = require('./includeQuotas');
 const includeAllEventData = require('./includeAllEventData');
 const removeNonpublicAnswers = require('./removeNonpublicAnswers');
 const formatOptionsAsArray = require('./formatOptionsAsArray');
+const addOpenStatus = require('./addOpenStatus');
 
 exports.before = {
   all: [],
@@ -18,7 +19,7 @@ exports.before = {
 exports.after = {
   all: [],
   find: [],
-  get: [removeNonpublicAnswers(), formatOptionsAsArray()],
+  get: [removeNonpublicAnswers(), formatOptionsAsArray(), addOpenStatus()],
   create: [],
   update: [],
   patch: [],

--- a/src/routes/SingleEvent/SingleEvent.js
+++ b/src/routes/SingleEvent/SingleEvent.js
@@ -210,8 +210,7 @@ class SingleEvent extends React.Component {
           ? event.quota.map((quota, index) => (
               <SignupButton
                 title={quota.title}
-                opens={event.registrationStartDate}
-                closes={event.registrationEndDate}
+                isOpen={event.isOpen}
                 openForm={() => this.openForm(quota)}
                 isOnly={event.quota.length === 1}
                 key={index}

--- a/src/routes/SingleEvent/components/SignupButton/SignupButton.js
+++ b/src/routes/SingleEvent/components/SignupButton/SignupButton.js
@@ -1,16 +1,11 @@
 import React from 'react';
-import moment from 'moment';
 import _ from 'lodash';
 import signupState from '../../../../utils/signupStateText';
 import './SignupButton.scss';
 
 export class SignupButton extends React.Component {
   render() {
-    const now = moment();
-
-    const isOpened = now.isSameOrAfter(moment(this.props.opens));
-    const isClosed = now.isSameOrAfter(moment(this.props.closes));
-    const isOpen = (isOpened && !isClosed) || _.isEmpty(this.props.opens) || _.isEmpty(this.props.closes);
+    const isOpen = this.props.isOpen;
 
     return (
       <p>
@@ -29,8 +24,7 @@ export class SignupButton extends React.Component {
 SignupButton.propTypes = {
   openForm: React.PropTypes.func.isRequired,
   title: React.PropTypes.string.isRequired,
-  opens: React.PropTypes.string,
-  closes: React.PropTypes.string,
+  isOpen: React.PropTypes.bool.isRequired,
   eventTime: React.PropTypes.string,
   isOnly: React.PropTypes.bool.isRequired,
 };


### PR DESCRIPTION
This PR adds a computed field, `isOpen` to the response of a `GET  /api/events/:id` so that the `SignupButton` depends only on the servers opinion whether the signup is open or not (instead of doing the check clientside). It doesn't yet implement the full websocket-sweetness and most of the datetime strings in the UI are still calculated from the clientside time, but this restricts the most vital functionality to only care about the server time.