### PR TITLE
Feature/Edit signup

### DIFF
--- a/server/mail/emails/confirmation/html.pug
+++ b/server/mail/emails/confirmation/html.pug
@@ -23,5 +23,5 @@ block mainContent
 					strong #{val.label}: 
 					| #{val.answer}
 	div.content-block
-		p.bodyText Mikäli haluat perua ilmoittautumisesi, voit tehdä sen painamalla tätä #[a( href=cancelLink ) linkkiä].
+		p.bodyText Mikäli haluat muokata tai perua ilmoittautumisesi, voit tehdä sen painamalla tätä #[a( href=cancelLink ) linkkiä].
 	

--- a/server/mail/index.js
+++ b/server/mail/index.js
@@ -65,7 +65,7 @@ const EmailService = {
     return email
       .render('../server/mail/emails/confirmation/html', brandedParams)
       .then(html => {
-        const subject = `Ilmoittautumisvahvistus: ${params.event.title}`;
+        const subject = `${params.edited ? 'Muokkaus' : 'Ilmoittautumis'}vahvistus: ${params.event.title}`;
         return EmailService.send(to, subject, html);
       });
   },

--- a/server/services/signup/hooks/getSignupAndEvent.js
+++ b/server/services/signup/hooks/getSignupAndEvent.js
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 const config = require('../../../../config/ilmomasiina.config'); // eslint-disable-line
 const md5 = require('md5');
 
@@ -5,38 +6,64 @@ module.exports = () => (hook) => {
   const models = hook.app.get('models');
   const id = hook.id;
   const editToken = hook.params.query.editToken;
+  const fields = [];
+  const userAnswers = [];
 
   if (editToken !== md5(`${`${hook.id}`}${config.editTokenSalt}`)) {
     throw new Error('Invalid editToken');
   }
 
-  return models.signup
-    .findOne({
-      where: {
-        id,
-      },
-    })
-    .then(signup =>
-      models.quota
-        .findOne({
-          where: {
-            id: signup.quotaId,
-          },
-        })
-        .then(quota =>
-          models.event
-            .findOne({
-              where: {
-                id: quota.eventId,
-              },
-            })
-            .then((event) => {
-              hook.result = {
-                signup,
-                event,
-              };
-              return hook;
-            }),
-        ),
+  return models.answer
+    .findAll({ where: { signupId: id } })
+    .then(answers => answers.map(answer => userAnswers.push(answer.dataValues)))
+    .then(() => models.signup
+      .findOne({
+        where: {
+          id,
+        },
+      })
+      .then(signup => {
+        if (signup === null) { // Event not found with id, probably deleted
+          hook.result = {
+            signup,
+            event: null,
+          };
+          return hook;
+        }
+        return models.quota
+          .findOne({
+            where: {
+              id: signup.quotaId,
+            },
+          })
+          .then(quota =>
+            models.event
+              .findOne({
+                where: {
+                  id: quota.eventId,
+                },
+              })
+              .then((event) =>
+                event.getQuestions().then((questions) => {
+                  questions.map((question) => {
+                    const answer = _.find(userAnswers, { questionId: question.id });
+
+                    if (answer) {
+                      fields.push({
+                        ...question.dataValues,
+                        answer: answer.answer,
+                        answerId: answer.id,
+                      });
+                    }
+                  });
+                  hook.result = {
+                    signup: { ...signup.dataValues, answers: fields },
+                    event,
+                  };
+                  return hook;
+                }),
+              ),
+          );
+      }),
     );
 };

--- a/server/services/signup/hooks/sendConfirmationMail.js
+++ b/server/services/signup/hooks/sendConfirmationMail.js
@@ -41,6 +41,7 @@ module.exports = () => (hook) => {
         .then((event) => {
           const params = {
             answers: fields,
+            edited: userAnswers.some(a => a.createdAt.getTime() !== a.updatedAt.getTime()),
             date: moment(event.dataValues.date).tz('Europe/Helsinki').format('DD.MM.YYYY HH:mm:ss'),
             event: event.dataValues,
             cancelLink: `${config.baseUrl}${config.prefixUrl}/signup/${hook.result.id}/${hook.data.editToken}`,

--- a/src/modules/editSignup/actions.js
+++ b/src/modules/editSignup/actions.js
@@ -41,6 +41,7 @@ export const getSignupAndEventAsync = (id, editToken) => (dispatch) => {
   return request('GET', `${PREFIX_URL}/api/signups/${id}?editToken=${editToken}`)
     .then(res => JSON.parse(res.body))
     .then((res) => {
+      if (res.signup === null) throw new Error('signup not found');
       dispatch(setSignupAndEvent(res.signup, res.event));
       return true;
     })

--- a/src/routes/EditSignup/EditSignup.scss
+++ b/src/routes/EditSignup/EditSignup.scss
@@ -4,5 +4,9 @@
   align-items: center;
   text-align: center;
   max-width: 600px;
-  margin: 0 auto;
+  margin: 0 auto 4em auto;
+}
+
+.form-wrapper {
+  margin: -22px 0;
 }

--- a/src/routes/EditSignup/components/EditForm/EditForm.js
+++ b/src/routes/EditSignup/components/EditForm/EditForm.js
@@ -131,24 +131,7 @@ export class EditForm extends React.Component {
   }
 
   render() {
-    const signupStatus = () => {
-      const { status, position, quotaId } = this.props.signup;
-      const { openQuotaSize } = this.props.event;
-      const quotas = this.props.event.quota;
-
-      if (status == 'in-quota') {
-        const quota = _.find(quotas, { id: quotaId });
-        return `Olet kiintiössä ${quota.title} sijalla ${position} / ${quota.size}.`;
-      }
-
-      if (status == 'in-open') {
-        return `Olet avoimessa kiintiössä sijalla ${position} / ${openQuotaSize}.`;
-      }
-
-      return `Olet jonossa sijalla ${position}.`;
-    };
     return (
-
       <div className="form-wrapper">
         <div className="container">
           <div className="col-xs-12 col-md-8 col-md-offset-2">

--- a/src/routes/EditSignup/components/EditForm/EditForm.js
+++ b/src/routes/EditSignup/components/EditForm/EditForm.js
@@ -1,0 +1,216 @@
+import React from 'react';
+import Formsy from 'formsy-react';
+import { Link } from 'react-router';
+import _ from 'lodash';
+
+import { CheckboxGroup, Select, Input, Textarea } from 'formsy-react-components';
+import './EditForm.scss';
+
+export class EditForm extends React.Component {
+  constructor(props) {
+    super(props);
+    this.parseSubmit = this.parseSubmit.bind(this);
+    this.setError = this.setError.bind(this)
+    this.state = { inputError: false }
+  }
+  setError() {
+    this.setState({ inputError: true })
+  }
+  parseSubmit(data) {
+    const answers = {
+      firstName: this.props.signup.firstName,
+      lastName: this.props.signup.lastName,
+      email: this.props.signup.email,
+      answers: [],
+    };
+
+    if (this.props.questions) {
+      answers.answers = this.props.questions
+        .map((question) => {
+          const questionId = question.id;
+          const answer = data[question.id];
+
+          if (answer && answer.length > 0) {
+            if (question.type === 'checkbox') {
+              return { id: question.answerId, questionId, answer: answer.join(';') };
+            }
+            return { id: question.answerId, questionId, answer };
+          }
+
+          return null;
+        })
+        .filter(x => x);
+    }
+
+    return this.props.submitForm(answers);
+  }
+
+  renderQuestionFields() {
+    return _.map(this.props.questions, (question) => {
+      const help = question.public ? 'Tämän kentän vastaukset ovat julkisia.' : null;
+
+      if (question.type === 'text') {
+        return (
+          <Input
+            name={String(question.id)}
+            label={question.question}
+            type="text"
+            required={question.required}
+            key={question.id}
+            help={help}
+            value={question.answer}
+          />
+        );
+      }
+      if (question.type === 'number') {
+        return (
+          <Input
+            name={String(question.id)}
+            label={question.question}
+            type="number"
+            required={question.required}
+            key={question.id}
+            help={help}
+            value={question.answer}
+          />
+        );
+      }
+
+      if (question.type === 'textarea') {
+        return (
+          <Textarea
+            className="open-question form-control"
+            rows={3}
+            cols={40}
+            name={String(question.id)}
+            label={question.question}
+            required={question.required}
+            key={question.id}
+            help={help}
+            value={question.answer}
+          />
+        );
+      }
+
+      if (question.type === 'select') {
+
+        let optionsArray = [{ label: "Valitse...", value: null }];
+
+        question.options.split(';').map(option => optionsArray.push({ label: option }));
+
+        return (
+          <Select
+            validations="isExisty"
+            name={String(question.id)}
+            label={question.question}
+            options={optionsArray}
+            required={question.required}
+            key={question.id}
+            help={help}
+            value={question.answer}
+          />
+        );
+      }
+
+      if (question.type === 'checkbox') {
+        return (
+          <CheckboxGroup
+            name={String(question.id)}
+            label={question.question}
+            required={question.required}
+            options={question.options.split(';').map(option => ({ label: option, value: option }))}
+            key={question.id}
+            help={help}
+            value={question.answer.split(';')}
+          />
+        );
+      }
+
+      return null;
+    });
+  }
+
+  render() {
+    const signupStatus = () => {
+      const { status, position, quotaId } = this.props.signup;
+      const { openQuotaSize } = this.props.event;
+      const quotas = this.props.event.quota;
+
+      if (status == 'in-quota') {
+        const quota = _.find(quotas, { id: quotaId });
+        return `Olet kiintiössä ${quota.title} sijalla ${position} / ${quota.size}.`;
+      }
+
+      if (status == 'in-open') {
+        return `Olet avoimessa kiintiössä sijalla ${position} / ${openQuotaSize}.`;
+      }
+
+      return `Olet jonossa sijalla ${position}.`;
+    };
+    return (
+
+      <div className="form-wrapper">
+        <div className="container">
+          <div className="col-xs-12 col-md-8 col-md-offset-2">
+            {this.state.inputError ? <p style={{ color: "#a94442" }}>Ilmoittautumisessasi on virheitä.</p> : null}
+            <h2>Muokkaa ilmoittautumista</h2>
+            {this.props.signup.status != null ? <p>{signupStatus()}</p> : null}
+
+            <Formsy.Form onValidSubmit={this.parseSubmit} onInvalidSubmit={this.setError}>
+              <Input
+                name="firstName"
+                value={this.props.signup.firstName}
+                label="Etunimi"
+                type="text"
+                placeholder="Etunimi"
+                disabled
+              />
+              <Input
+                name="lastName"
+                value={this.props.signup.lastName}
+                label="Sukunimi"
+                type="text"
+                placeholder="Sukunimi"
+                disabled
+              />
+
+              <Input
+                name="email"
+                value={this.props.signup.email}
+                label="Sähköposti"
+                type="email"
+                placeholder="Sähköpostisi"
+                validations="isEmail"
+                disabled
+              />
+
+              {this.renderQuestionFields()}
+
+              <div className="input-wrapper pull-right">
+                <input
+                  className="btn btn-primary pull-right"
+                  formNoValidate
+                  type="submit"
+                  defaultValue="Päivitä"
+                  disabled={this.props.loading}
+                />
+              </div>
+              <Link className="btn btn-link pull-right" to={`${PREFIX_URL}/`} >
+                Peruuta
+              </Link>
+            </Formsy.Form>
+          </div>
+          <div className="cf" />
+        </div>
+      </div >
+    );
+  }
+}
+
+EditForm.propTypes = {
+  questions: React.PropTypes.array,
+  signup: React.PropTypes.object,
+  loading: React.PropTypes.bool,
+};
+
+export default EditForm;

--- a/src/routes/EditSignup/components/EditForm/EditForm.scss
+++ b/src/routes/EditSignup/components/EditForm/EditForm.scss
@@ -1,0 +1,63 @@
+.close {
+  position: absolute;
+  right: 30px;
+  top: 30px;
+  display: inline-block;
+  width: 40px;
+  height: 40px;
+  overflow: hidden;
+  cursor: pointer;
+
+  &::before,
+  &::after {
+    content: '';
+    position: absolute;
+    height: 1px;
+    width: 100%;
+    top: 50%;
+    left: 0;
+    margin-top: -1px;
+    background: $alt-text;
+  }
+  &:before {
+    transform: (rotate(45deg));
+  }
+  &:after {
+    transform: (rotate(-45deg));
+  }
+
+  &:hover {
+    &:before,
+    &:after {
+      background: lighten($alt-text, 20%);
+    }
+  }
+}
+
+.form-wrapper {
+  width: 100%;
+  margin: -22px 0 3em;
+  padding: 4em 0;
+  position: relative;
+
+  p {
+    margin: 2em 0;
+  }
+}
+
+.input-wrapper {
+  position: relative;
+}
+
+.loading-wrapper {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 1em;
+  background: $green;
+
+  display: flex;
+  justify-content: center;
+  align-items: center; 
+}

--- a/src/routes/EditSignup/components/EditForm/index.js
+++ b/src/routes/EditSignup/components/EditForm/index.js
@@ -1,0 +1,3 @@
+import { EditForm } from './EditForm';
+
+export default EditForm;


### PR DESCRIPTION
This PR will allow the user to edit their signups. It adds a form with the signup questions that is prefilled with the original answers:

![Screenshot from 2019-04-08 21-05-08](https://user-images.githubusercontent.com/16649390/55746347-295fdb00-5a42-11e9-80f2-1a82428f0d54.png)

The name and email fields are disabled from editing, as those most likely should never be changed. After the user has edited their signup they will receive an additional mail confirming the edits.