### PR TITLE
Feature/email text in English

### DIFF
--- a/server/mail/emails/confirmation/html.pug
+++ b/server/mail/emails/confirmation/html.pug
@@ -3,25 +3,6 @@ extends ../layout.pug
 block mainContent
 	div.content-block
 		p.bodyText #{event.verificationEmail}
-	div.content-block
-		p.bodyText Tapahtuman tiedot:
-		ul
-			li
-				strong Tapahtuma: 
-				| #{event.title}
-			li 
-				strong Sijainti: 
-				| #{event.location}
-			li 
-				strong Aika: 
-				| #{date}
-	div.content-block
-		p.bodyText Ilmoittautumisesi tiedot:
-		ul
-			each val in answers
-				li
-					strong #{val.label}: 
-					| #{val.answer}
-	div.content-block
-		p.bodyText Mikäli haluat muokata tai perua ilmoittautumisesi, voit tehdä sen painamalla tätä #[a( href=cancelLink ) linkkiä].
-	
+	include ../event_information.pug 
+	include ../signup_details.pug
+	include ../edit_or_cancel.pug

--- a/server/mail/emails/edit_or_cancel.pug
+++ b/server/mail/emails/edit_or_cancel.pug
@@ -1,0 +1,3 @@
+div.content-block
+    p.bodyText Mikäli haluat muokata tai perua ilmoittautumisesi, voit tehdä sen painamalla tätä #[a( href=cancelLink ) linkkiä].
+    p.bodyText If you want to edit or cancel your signup, please use this #[a( href=cancelLink ) link].

--- a/server/mail/emails/event_information.pug
+++ b/server/mail/emails/event_information.pug
@@ -1,0 +1,12 @@
+div.content-block
+    p.bodyText Tapahtuman tiedot // Event information:
+    ul
+        li
+            strong Tapahtuma // Event: 
+            | #{event.title}
+        li 
+            strong Sijainti // Location: 
+            | #{event.location}
+        li 
+            strong Aika // Date: 
+            | #{date}

--- a/server/mail/emails/newUser/html.pug
+++ b/server/mail/emails/newUser/html.pug
@@ -2,10 +2,10 @@ extends ../layout.pug
 
 block mainContent
 	div.content-block
-		p.bodyText Sinulle on luotu admin-tunnukset Ilmomasiinaan.:
+		p.bodyText Sinulle on luotu admin-tunnukset Ilmomasiinaan // Ilmomasiina admin credentials have been created for you:
 		ul
 			each val in fields
 				li
 					strong #{val.label}:
 					| #{val.answer}
-	p.bodyText Voit kirjautua sisään osoitteessa #{branding.siteUrl}:
+	p.bodyText Voit kirjautua sisään osoitteessa // You may log in at #{branding.siteUrl}

--- a/server/mail/emails/queueMail/html.pug
+++ b/server/mail/emails/queueMail/html.pug
@@ -3,17 +3,6 @@ extends ../layout.pug
 block mainContent
 	div.content-block
 		p.bodyText Olet päässyt mukaan tapahtumaan #{event.title} varasijalta.
-	div.content-block
-		p.bodyText Tapahtuman tiedot:
-		ul
-			li
-				strong Tapahtuma: 
-				| #{event.title}
-			li 
-				strong Sijainti: 
-				| #{event.location}
-			li 
-				strong Aika: 
-				| #{date}
-	div.content-block
-		p.bodyText Mikäli haluat muokata tai perua ilmoittautumisesi, voit tehdä sen painamalla tätä #[a( href=cancelLink ) linkkiä].
+		p.bodyText You now have a spot at #{event.title} because the queue moved.
+	include ../event_information.pug
+	include ../edit_or_cancel.pug

--- a/server/mail/emails/queueMail/html.pug
+++ b/server/mail/emails/queueMail/html.pug
@@ -3,6 +3,6 @@ extends ../layout.pug
 block mainContent
 	div.content-block
 		p.bodyText Olet päässyt mukaan tapahtumaan #{event.title} varasijalta.
-		p.bodyText You now have a spot at #{event.title} because the queue moved.
+		p.bodyText You now have a spot at #{event.title} because someone cancelled.
 	include ../event_information.pug
 	include ../edit_or_cancel.pug

--- a/server/mail/emails/signup_details.pug
+++ b/server/mail/emails/signup_details.pug
@@ -1,0 +1,7 @@
+div.content-block
+    p.bodyText Ilmoittautumisesi tiedot // Signup details:
+    ul
+        each val in answers
+            li
+                strong #{val.label}: 
+                | #{val.answer}

--- a/server/mail/templateTest.js
+++ b/server/mail/templateTest.js
@@ -1,0 +1,38 @@
+const pug = require('pug')
+
+// this is not a proper test file, but should make it easier to check that
+// emails are still e.g. rendering
+// this will likely just crash when major problems occur
+
+const templateVars = {
+  event: {
+    title: 'Event title',
+    date: '2021',
+    location: 'Online',
+    verificationEmail: 'this is verification test',
+  },
+  cancelLink: 'https://athene.fi/ilmo/',
+  answers: [],
+  branding: {
+    footerText: 'This is footer text',
+    footerLink: 'https://athene.fi/ilmo?ref=footer-test'
+  },
+  val: {
+    label: '',
+    answer: '',
+  },
+  fields: [],
+}
+
+console.log('printing rendered emails (html)...')
+const results = {
+  confirmation: pug.renderFile('emails/confirmation/html.pug', templateVars),
+  newUser: pug.renderFile('emails/newUser/html.pug', templateVars),
+  queueMail: pug.renderFile('emails/queueMail/html.pug', templateVars),
+}
+Object.keys(results).forEach(k => console.log(`${k}:\n`, results[k]))
+
+console.log(
+  'each render should be longer than 0 characters:',
+  Object.values(results).every(html => html.length > 0)  
+)


### PR DESCRIPTION
This PR adds English translations to email templates. This is required as not all Ilmomasiina users understand Finnish.

There's no fancy localization for now, but templates include the same information in both Finnish and English. This is the same approach as has been used when localizing event information and questions.