### PR TITLE
add docker-compose env + update readme

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+Dockerfile
+docker-compose.yaml
+Procfile
+*.md
+docs
+.git*
+LICENSE*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:8.9.4-alpine
+
+ADD . /opt/ilmomasiina
+WORKDIR /opt/ilmomasiina
+RUN adduser -D athene
+RUN chown -R athene /opt/ilmomasiina
+USER athene
+RUN npm install
+ENTRYPOINT ["npm", "start"]

--- a/ENV.MD
+++ b/ENV.MD
@@ -3,6 +3,7 @@
 ```bash
 MYSQL_USER=your-mysql-user
 MYSQL_PASSWORD=your-mysql-password
+MYSQL_ROOT_PASSWORD=your-mysql-password
 MYSQL_DATABASE=ilmomasiina
 ADMIN_REGISTRATION_ALLOWED=true
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ```
 
-Current defelopment is being held on `otax/production` branch.
+Current development is being held on `otax/production` branch.
 
 
 # Ilmomasiina
@@ -21,9 +21,25 @@ Ilmomasiina is Athene's event registration system.
 - Node.js `^8.9.4`
 - npm `^5.6.0`
 - MySQL `^8.0`
+- (optional) Docker and Docker-compose
 
-## MYSQL Setup
-### Mac
+## Setup the development environment 
+
+Create an `.env` file at the root of the project. For the contents of the .env file, check [ENV.MD](./ENV.MD)
+
+## Option 1: Docker-compose
+Fastest way to get started, which involves the less requirements and setup. If you do not have docker and docker-compose, follow this [link to get started](https://docs.docker.com/compose/install/)
+
+From the root folder, run `docker-compose up` and you should be able to reach the app at `localhost:3000`.
+When you change the source code and would like to update the changes to the container, run `docker-compose build` followed by `docker-compose-up`.
+
+To generate random fake data to the database, run `docker exec -it ilmomasiina_backend_1 npm run create-fake-data`
+
+## Option 2: install locally all dependencies
+The following sections help you setup locally dependencies to run the app.
+
+### MYSQL Setup
+#### Mac
 1. Install `mysql` (8.x) with Homebrew (https://gist.github.com/nrollr/3f57fc15ded7dddddcc4e82fe137b58e)
 2. Start the mysql service with `brew services start mysql`
 3. Open the mysql terminal with `mysql -u root`
@@ -32,7 +48,7 @@ Ilmomasiina is Athene's event registration system.
 6. Type `exit` to exit the mysql terminal, and sign in with your new user e.g. `mysql -u juuso -p password`
 7. Create the `ilmomasiina` database with `CREATE DATABASE ilmomasiina;`
 
-### Ubuntu
+#### Ubuntu
 1. Install mysql with `sudo apt install mysql-server`
 2. Service should start automatically
 3. Same as with Mac, but use `sudo mysql -u root`
@@ -41,7 +57,7 @@ Ilmomasiina is Athene's event registration system.
 6. Exit with `exit` and sign in with your new user e. g. `mysql -u juuso -p` (don't use `mysql -u juuso -p password`)
 7. Follow Mac instructions step 6 
 
-### Debian GNU/Linux (9 and above)
+#### Debian GNU/Linux (9 and above)
 Debian includes [MariaDB instead of MySQL](https://wiki.debian.org/MySql) in Debian Stretch and above.
 Below instructions are written using `mariadb  Ver 15.1 Distrib 10.5.12-MariaDB`.
 
@@ -55,11 +71,10 @@ Below instructions are written using `mariadb  Ver 15.1 Distrib 10.5.12-MariaDB`
 
 If needed (during development), you can sign in with your user using command like `mysql -u sampo -p`
 
-## Getting started
+### Getting started
 
-1. Create an `.env` file at the root of the project. For the contents of the .env file, check [ENV.MD](./ENV.MD)
-2. `npm install`
-3. `npm start`
+1. `npm install`
+2. `npm start`
 
 **Optional**: You can create mockup data for development by running `npm run create-fake-data`. During development, database can be resetted with `npm run reset-db`.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,11 @@ Fastest way to get started, which involves the less requirements and setup. If y
 From the root folder, run `docker-compose up` and you should be able to reach the app at `localhost:3000`.
 When you change the source code and would like to update the changes to the container, run `docker-compose build` followed by `docker-compose-up`.
 
-To generate random fake data to the database, run `docker exec -it ilmomasiina_backend_1 npm run create-fake-data`
+To generate random fake data to the database, run `docker exec -it ilmomasiina_backend_1 npm run create-fake-data`.
+
+It is not required to build the docker image once changes are made: `./bin`, `./src`, `./servcer`, `./public` and `./config` are automatically synced to the container. If you do modify files in these paths, reload the web page and changes should be seen.
+
+When changes are made to other directories, run `docker-compose build` followed by `docker-compose up`. Though these paths do not contain components that are directly used by the web app at runtime.
 
 ## Option 2: install locally all dependencies
 The following sections help you setup locally dependencies to run the app.

--- a/config/project.config.js
+++ b/config/project.config.js
@@ -24,7 +24,8 @@ const config = {
   // ----------------------------------
   // Server Configuration
   // ----------------------------------
-  server_host : ip.address(), // use string 'localhost' to prevent exposure on local network
+  // Prevents the use of ip address if ran in container, as the ip address is unreachable.
+  server_host : process.env.DOCKER_ENV || ip.address(), // use string 'localhost' to prevent exposure on local network
   server_port : process.env.PORT || 3000,
 
   // ----------------------------------

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,6 +18,12 @@ services:
         environment: 
             - MYSQL_HOST=database   #See ./server/models/index.js:26
             - DOCKER_ENV=localhost  #See ./config/project.config.js:28
+        volumes:
+            - ./src:/opt/ilmomasiina/src
+            - ./server:/opt/ilmomasiina/server
+            - ./public:/opt/ilmomasiina/public
+            - ./config:/opt/ilmomasiina/config
+            - ./bin:/opt/ilmomasiina/bin
         env_file:
             - .env
         ports:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
             - .env
         healthcheck:
             test: ["CMD", "curl", "-f", "http://localhost:3306"]
-            interval: 10s
+            interval: 2s
             timeout: 5s
             retries: 5
         ports:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,26 @@
+version: '3'
+services:
+    database:
+        image: mysql:8
+        command: --default-authentication-plugin=mysql_native_password
+        env_file:
+            - .env
+        healthcheck:
+            test: ["CMD", "curl", "-f", "http://localhost:3306"]
+            interval: 10s
+            timeout: 5s
+            retries: 5
+        ports:
+          - "3306:3306"
+    backend:
+        # Use Dockerfile from root directory
+        build: .
+        environment: 
+            - MYSQL_HOST=database   #See ./server/models/index.js:26
+            - DOCKER_ENV=localhost  #See ./config/project.config.js:28
+        env_file:
+            - .env
+        ports:
+            - "3000:3000"
+        depends_on: 
+            - database

--- a/package-lock.json
+++ b/package-lock.json
@@ -6644,8 +6644,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6663,15 +6662,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
-            "balanced-match": "^1.0.0",
+            "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -6682,18 +6679,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6705,7 +6699,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         },
         "deep-extend": {
@@ -6782,7 +6776,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "minimatch": "^3.0.4"
+            "minimatch": "3.0.4"
           }
         },
         "inflight": {
@@ -6796,8 +6790,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6807,9 +6800,8 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "isarray": {
@@ -6820,15 +6812,13 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
@@ -6849,7 +6839,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6911,8 +6900,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.6"
           }
         },
         "npmlog": {
@@ -6928,8 +6917,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -23,7 +23,7 @@ module.exports = function() {
       config.mysqlUser,
       config.mysqlPassword,
       {
-        host: 'localhost',
+        host: process.env.MYSQL_HOST || 'localhost', // If ran in Docker, uses db from compose. Else, uses localhost db.
         dialect: 'mysql',
         logging: false,
       },


### PR DESCRIPTION
# Add docker environment
To simplify the setup of local environment, uses docker-compose to setup the project and database. 

## Modification to source code
Even though I mostly added support for docker-compose, which is not involved in the source code, I had to modify 2 small things. Both modification add support for container while keeping support for local environment setup.

1. The sequelize function could not find the database if the host was set to localhost (obviously), so added a check of env variable in `server/models/index.js` to reach the correct endpoint.
2. Set the server_host variable in `config/config.project.js` to localhost if the env variable is set: if using ip.address, the container will serve files from its own ip address, which is not routable outside the container network and hence not reachable from localhost.

From my tests on MacOS, I could run the app with both `docker-compose` and `npm start`.
