### PR TITLE
Add empty field to db when question isn't answered

### DIFF
--- a/server/mail/index.js
+++ b/server/mail/index.js
@@ -44,7 +44,6 @@ const EmailService = {
         const subjectFi = `${params.edited ? 'Muokkaus' : 'Ilmoittautumis'}vahvistus: ${params.event.title}`;
         const subjectEn = `${params.edited ? 'Signup edit' : 'Signup'} confirmation: ${params.event.title}`;
         const subject = subjectFi + ' // ' + subjectEn;
-        console.log(html)
         return EmailService.send(to, subject, html);
       });
   },

--- a/server/models/quota.js
+++ b/server/models/quota.js
@@ -12,10 +12,6 @@ module.exports = function () {
     size: {
       type: Sequelize.INTEGER,
     },
-    sortId: {
-      type: Sequelize.INTEGER,
-      allowNull: false,
-    }
   }, {
     freezeTableName: true,
     paranoid: true,

--- a/server/services/admin/events/hooks/includeQuotas.js
+++ b/server/services/admin/events/hooks/includeQuotas.js
@@ -21,7 +21,6 @@ module.exports = () => hook => {
         attributes: [
           'title',
           'size',
-          'sortId',
           [
             sequelize.fn('COUNT', sequelize.col('quota->signups.id')),
             'signupCount',

--- a/server/services/admin/events/hooks/updateQuestions.js
+++ b/server/services/admin/events/hooks/updateQuestions.js
@@ -25,7 +25,7 @@ module.exports = () => (hook) => {
       hook.result.dataValues.questions = questions;
       return hook;
     }).catch((error => {
-      throw new Error('Question update failed:', error);
+      throw new Error('Question update failed');
     }));
 
 };

--- a/server/services/admin/events/hooks/updateQuotas.js
+++ b/server/services/admin/events/hooks/updateQuotas.js
@@ -28,10 +28,9 @@ module.exports = () => (hook) => {
     });
   }).then((quota) => {
     hook.result.dataValues.quota = quota;
-    console.log(quota)
     return hook;
   }).catch((error => {
-    throw new Error('Quota update failed:', error);
+    throw new Error('Quota update failed');
   }));
 
 

--- a/src/routes/Editor/components/QuotasTab.js
+++ b/src/routes/Editor/components/QuotasTab.js
@@ -42,7 +42,6 @@ class QuotasTab extends React.Component {
       id: (_.max(quotas.map(n => n.id)) || 0) + 1,
       title: '',
       existsInDb: false,
-      sortId: (_.max(quotas.map(n => n.sortId)) || 0) + 1,
     });
 
     this.props.onDataChange('quota', newQuotas);
@@ -50,8 +49,6 @@ class QuotasTab extends React.Component {
 
   updateOrder(args) {
     let newQuotas = this.props.event.quota;
-    console.log(args)
-    console.log(newQuotas)
     const elementToMove = newQuotas[args.oldIndex];
     newQuotas.splice(args.oldIndex, 1);
     newQuotas.splice(args.newIndex, 0, elementToMove);


### PR DESCRIPTION
After a lot of struggles, here's my conclusion :D 

- Inserting empty strings works, but it requires to remove validation on `checkboxe` and `select`. I am wondering why is there such validation in the first place ? Since you can only choose from the given answers :D Drawback of this solution: inserts lines in db even if no answers, so db grows is bigger.

- Mapping questions to answers in the edit form. This does not need to remove the validation, but creates more code and I/O on the db as whenever you need to edit the event, it also requests the question in the db and the client then needs to compare questions which have answers and those who have not.

The problem then comes from removing one of your answers. Let's say: 
- I answer `yes` to `Are you the most handsome man on the planet?`
- I realize that's it's a bit cocky, I am only the 2nd most handsome, so I want to remove the answer.
- Since currently questions without answers are not inserted, the answer stays.

The solution is then to insert empty lines if there are no answers, or to delete in db if someone removed their answer in the form, which is kind of a pain to implement. This is why I think it's better to insert empty lines at the enrollment anyways, as editing supports easier this option.

Let me know if this okay for you.