### PR TITLE
Add a sortId to quotas, so they can be rearranged

### DIFF
--- a/server/models/question.js
+++ b/server/models/question.js
@@ -13,6 +13,10 @@ module.exports = function () {
       type: Sequelize.STRING,
       allowNull: false,
     },
+    sortId: {
+      type: Sequelize.INTEGER,
+      allowNull: false,
+    },
     options: {
       type: Sequelize.STRING,
     },

--- a/server/models/quota.js
+++ b/server/models/quota.js
@@ -12,6 +12,10 @@ module.exports = function () {
     size: {
       type: Sequelize.INTEGER,
     },
+    sortId: {
+      type: Sequelize.INTEGER,
+      allowNull: false,
+    }
   }, {
     freezeTableName: true,
     paranoid: true,

--- a/server/services/admin/events/hooks/includeAllEventData.js
+++ b/server/services/admin/events/hooks/includeAllEventData.js
@@ -1,6 +1,5 @@
 module.exports = () => hook => {
   const sequelize = hook.app.get('sequelize');
-
   hook.params.sequelize = {
     distinct: true,
     raw: false,
@@ -20,6 +19,9 @@ module.exports = () => hook => {
       'signupsPublic',
       'verificationEmail',
     ],
+    order: [
+      [{ model: sequelize.models.quota }, 'sortId', 'ASC'],
+    ],
     include: [
       // First include all questions
       {
@@ -30,6 +32,7 @@ module.exports = () => hook => {
       {
         attributes: ['title', 'size', 'id', 'sortId'],
         model: sequelize.models.quota,
+        
         // include: [
         //   {
         //     all: true,

--- a/server/services/admin/events/hooks/includeAllEventData.js
+++ b/server/services/admin/events/hooks/includeAllEventData.js
@@ -21,11 +21,12 @@ module.exports = () => hook => {
     ],
     order: [
       [{ model: sequelize.models.quota }, 'sortId', 'ASC'],
+      [{ model: sequelize.models.question }, 'sortId', 'ASC'],
     ],
     include: [
       // First include all questions
       {
-        attributes: ['id', 'question', 'type', 'options', 'required', 'public'],
+        attributes: ['id', 'question', 'type', 'options', 'required', 'public', 'sortId'],
         model: sequelize.models.question,
       },
       // Include quotas..

--- a/server/services/admin/events/hooks/includeAllEventData.js
+++ b/server/services/admin/events/hooks/includeAllEventData.js
@@ -28,7 +28,7 @@ module.exports = () => hook => {
       },
       // Include quotas..
       {
-        attributes: ['title', 'size', 'id'],
+        attributes: ['title', 'size', 'id', 'sortId'],
         model: sequelize.models.quota,
         // include: [
         //   {

--- a/server/services/admin/events/hooks/includeQuotas.js
+++ b/server/services/admin/events/hooks/includeQuotas.js
@@ -21,6 +21,7 @@ module.exports = () => hook => {
         attributes: [
           'title',
           'size',
+          'sortId',
           [
             sequelize.fn('COUNT', sequelize.col('quota->signups.id')),
             'signupCount',

--- a/server/services/admin/events/hooks/updateQuestions.js
+++ b/server/services/admin/events/hooks/updateQuestions.js
@@ -25,7 +25,7 @@ module.exports = () => (hook) => {
       hook.result.dataValues.questions = questions;
       return hook;
     }).catch((error => {
-      throw new Error('Question update failed');
+      throw new Error('Question update failed:', error);
     }));
 
 };

--- a/server/services/admin/events/hooks/updateQuotas.js
+++ b/server/services/admin/events/hooks/updateQuotas.js
@@ -30,7 +30,7 @@ module.exports = () => (hook) => {
     hook.result.dataValues.quota = quota;
     return hook;
   }).catch((error => {
-    throw new Error('Quota update failed');
+    throw new Error('Quota update failed:', error);
   }));
 
 

--- a/server/services/event/hooks/includeAllEventData.js
+++ b/server/services/event/hooks/includeAllEventData.js
@@ -28,7 +28,7 @@ module.exports = () => hook => {
       },
       // Include quotas..
       {
-        attributes: ['title', 'size', 'id'],
+        attributes: ['title', 'size', 'id', 'sortId'],
         model: sequelize.models.quota,
         // ... and signups of quotas
         include: [

--- a/server/services/event/hooks/includeAllEventData.js
+++ b/server/services/event/hooks/includeAllEventData.js
@@ -23,7 +23,7 @@ module.exports = () => hook => {
     include: [
       // First include all questions (also non-public for the form)
       {
-        attributes: ['id', 'question', 'type', 'options', 'required', 'public'],
+        attributes: ['id', 'question', 'type', 'options', 'required', 'public', 'sortId'],
         model: sequelize.models.question,
       },
       // Include quotas..

--- a/server/services/event/hooks/includeQuotas.js
+++ b/server/services/event/hooks/includeQuotas.js
@@ -29,6 +29,7 @@ module.exports = () => hook => {
         attributes: [
           'title',
           'size',
+          'sortId',
           [
             sequelize.fn('COUNT', sequelize.col('quota->signups.id')),
             'signupCount',

--- a/src/routes/Editor/Editor.js
+++ b/src/routes/Editor/Editor.js
@@ -69,7 +69,7 @@ class Editor extends React.Component {
           this.props.setEvent({});
 
           // Set base quota field
-          this.props.updateEventField('quota', [{ id: 0, title: 'Kiintiö', size: 20, existsInDb: false }]);
+          this.props.updateEventField('quota', [{ id: 0, title: 'Kiintiö', size: 20, existsInDb: false, sortId: 1 }]);
           this.props.updateEventField('questions', []);
         } else {
           this.props.getEventAsync(eventId, adminToken);

--- a/src/routes/Editor/Editor.js
+++ b/src/routes/Editor/Editor.js
@@ -69,7 +69,7 @@ class Editor extends React.Component {
           this.props.setEvent({});
 
           // Set base quota field
-          this.props.updateEventField('quota', [{ id: 0, title: 'Kiintiö', size: 20, existsInDb: false, sortId: 1 }]);
+          this.props.updateEventField('quota', [{ id: 0, title: 'Kiintiö', size: 20, existsInDb: false, sortId: 0 }]);
           this.props.updateEventField('questions', []);
         } else {
           this.props.getEventAsync(eventId, adminToken);

--- a/src/routes/Editor/components/QuestionsTab.js
+++ b/src/routes/Editor/components/QuestionsTab.js
@@ -49,6 +49,7 @@ class QuestionsTab extends React.Component {
 
     const newQuestions = _.concat(questions, {
       id: (_.max(questions.map(n => n.id)) || 0) + 1,
+      sortId: (_.max(questions.map(n => n.sortId)) || -1) + 1,
       existsInDb: false,
       required: false,
       public: false,
@@ -65,7 +66,9 @@ class QuestionsTab extends React.Component {
     const elementToMove = newQuestions[args.oldIndex];
     newQuestions.splice(args.oldIndex, 1);
     newQuestions.splice(args.newIndex, 0, elementToMove);
-
+    for (let index = 0; index < newQuestions.length; index++) {
+      newQuestions[index].sortId = index
+    } 
     this.props.onDataChange('questions', newQuestions);
   }
 

--- a/src/routes/Editor/components/QuotasTab.js
+++ b/src/routes/Editor/components/QuotasTab.js
@@ -30,7 +30,7 @@ class QuotasTab extends React.Component {
 
   constructor(props) {
     super(props);
-
+    
     this.addQuota = this.addQuota.bind(this);
     this.updateQuota = this.updateQuota.bind(this);
     this.updateOrder = this.updateOrder.bind(this);
@@ -52,7 +52,9 @@ class QuotasTab extends React.Component {
     const elementToMove = newQuotas[args.oldIndex];
     newQuotas.splice(args.oldIndex, 1);
     newQuotas.splice(args.newIndex, 0, elementToMove);
-
+    for (let index = 0; index < newQuotas.length; index++) {
+      newQuotas[index].sortId = index
+    } 
     this.props.onDataChange('quota', newQuotas);
   }
 
@@ -73,9 +75,7 @@ class QuotasTab extends React.Component {
             [field]: value,
           };
         }
-
       }
-
       return quota;
     });
 
@@ -96,6 +96,7 @@ class QuotasTab extends React.Component {
   }
 
   renderQuotas() {
+
     const q = _.map(this.props.event.quota, (item, index) => (
       <div className="panel-body">
         <div className="col-xs-12 col-sm-10">

--- a/src/routes/Editor/components/QuotasTab.js
+++ b/src/routes/Editor/components/QuotasTab.js
@@ -42,6 +42,7 @@ class QuotasTab extends React.Component {
       id: (_.max(quotas.map(n => n.id)) || 0) + 1,
       title: '',
       existsInDb: false,
+      sortId: (_.max(quotas.map(n => n.sortId)) || -1) + 1,
     });
 
     this.props.onDataChange('quota', newQuotas);
@@ -96,7 +97,6 @@ class QuotasTab extends React.Component {
   }
 
   renderQuotas() {
-
     const q = _.map(this.props.event.quota, (item, index) => (
       <div className="panel-body">
         <div className="col-xs-12 col-sm-10">


### PR DESCRIPTION
Added the sortId field, which will be used to rearrange quotas since we can't modify their ids.

The db queries now sorts based on sortId, so the list of quotas it returns is ready to be used by the component. When a component is moved, change its sortId accordingly. Also add a default sortId of 0 to the first quota which is by default created when an event is created.