### PR TITLE
Fix sorting of dates

### DIFF
--- a/src/utils/signupUtils.js
+++ b/src/utils/signupUtils.js
@@ -79,19 +79,15 @@ export const getSignupsArray = (event, includeWaitlist = true) => {
 
 export const getSignupsArrayFormatted = (event, includeWaitlist = true) => {
 	const signupsArray = getSignupsArray(event, includeWaitlist);
-
 	const sorted = _.sortBy(signupsArray, (s) => {
-
-		if (s.isOpenQuota) {
-			return new Date(s.createdAt) + 315360000000
-		}
-
-		if (s.isWaitlist) {
-			return new Date(s.createdAt) + 315360000000 * 2;
-		}
-
-		return new Date(s.createdAt);
-	});
+  if (s.isOpenQuota) {
+    return new moment(s.createdAt).add(10, 'y').toDate();
+  }
+  if (s.isWaitlist) {
+    return new moment(s.createdAt).add(20, 'y').toDate();
+  }
+  return new Date(s.createdAt);
+});
 
 	return _.map(sorted, (signup) => {
 


### PR DESCRIPTION
As discussed in all-stars telegram channel, 10 years are added to openquota and 20 to waiting list, but just for sorting purposes. However the way it is currently implemented, it just adds the number at the end of the date instead of adding to the date. Fix it so the sorting is fixed in admin signup tab.

I am sure there's a better way to do this sorting but do we have time ? :D 